### PR TITLE
Build: Export lcsget and public key hash APIs

### DIFF
--- a/codesafe/src/secure_boot_debug/platform/stage/rt/cc3x/secureboot_stage_defs.h
+++ b/codesafe/src/secure_boot_debug/platform/stage/rt/cc3x/secureboot_stage_defs.h
@@ -26,7 +26,7 @@ extern "C"
 #include "crypto_driver.h"
 #include "bsv_hw_defs.h"
 #include "sbrt_int_func.h"
-#include "mbedtls_cc_mng.h"
+#include "mbedtls_cc_mng_int.h"
 #include "pka_hw_defs.h"
 
 extern unsigned long gCcRegBase;

--- a/host/src/cc3x_lib/Makefile
+++ b/host/src/cc3x_lib/Makefile
@@ -42,7 +42,7 @@ PUBLIC_INCLUDES += $(MBEDTLS_ALT_API)/config-cc312.h $(MBEDTLS_ALT_API)/config-c
 PUBLIC_INCLUDES += $(MBEDTLS_ALT_API)/cmac_alt.h $(MBEDTLS_ALT_API)/dhm_alt.h $(MBEDTLS_ALT_API)/chacha20_alt.h $(MBEDTLS_ALT_API)/poly1305_alt.h $(MBEDTLS_ALT_API)/chachapoly_alt.h
 PUBLIC_INCLUDES += $(MBEDTLS_ALT_API)/cc_ecc_internal.h $(CC_API_3x)/mbedtls_cc_ecdsa_edwards.h $(CC_API_3x)/mbedtls_cc_ecdh_edwards.h
 
-PUBLIC_INCLUDES += $(MANAGEMENT_INCLUDES)/mbedtls_cc_mng.h $(MANAGEMENT_INCLUDES)/mbedtls_cc_mng_error.h
+PUBLIC_INCLUDES += $(MANAGEMENT_INCLUDES)/mbedtls_cc_mng.h $(MANAGEMENT_INCLUDES)/mbedtls_cc_mng_error.h $(MANAGEMENT_API)/mbedtls_cc_mng_common.h $(HOST_PROJ_ROOT)/src/hal/cc_hal_plat.h
 PUBLIC_INCLUDES += $(SHARED_INCDIR)/cc_util/mbedtls_cc_util_key_derivation.h $(SHARED_INCDIR)/cc_util/mbedtls_cc_util_key_derivation_defs.h $(SHARED_INCDIR)/cc_util/mbedtls_cc_util_defs.h
 PUBLIC_INCLUDES += $(SHARED_INCDIR)/cc_util/cc_util_error.h
 

--- a/host/src/cc_mng/mbedtls_cc_mng_common.h
+++ b/host/src/cc_mng/mbedtls_cc_mng_common.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2001-2019, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause OR Arm’s non-OSI source license
+ */
+
+#ifndef _MBEDTLS_CC_MNG_COMMON_H
+#define _MBEDTLS_CC_MNG_COMMON_H
+
+/************************ Includes ******************************/
+#include <stdint.h>
+
+/************************ Enums ******************************/
+/*! HASH boot key definition. */
+typedef enum {
+    CC_MNG_HASH_BOOT_KEY_0_128B         = 0,        /*!< 128-bit truncated SHA256 digest of public key 0. */
+    CC_MNG_HASH_BOOT_KEY_1_128B     = 1,        /*!< 128-bit truncated SHA256 digest of public key 1. */
+    CC_MNG_HASH_BOOT_KEY_256B       = 2,        /*!< 256-bit SHA256 digest of public key. */
+    CC_MNG_HASH_BOOT_NOT_USED       = 0xF,
+    CC_MNG_HASH_MAX_NUM                 = 0x7FFFFFFF,   /*!\internal use external 128-bit truncated SHA256 digest */
+}mbedtls_mng_pubKeyType_t;
+
+/************************ Defines ******************************/
+/* LCS. */
+/*! Chip manufacturer (CM LCS). */
+#define CC_MNG_LCS_CM       0x0
+/*! Device manufacturer (DM LCS). */
+#define CC_MNG_LCS_DM       0x1
+/*! Security enabled (Secure LCS). */
+#define CC_MNG_LCS_SEC_ENABLED  0x5
+/*! RMA (RMA LCS). */
+#define CC_MNG_LCS_RMA      0x7
+
+/************************ API's ******************************/
+/*!
+@brief This function reads an OTP word from from 'otpAddress' to 'pOtpWord'.
+
+@return CC_OK on success.
+@return A non-zero value from cc_manage.h on failure.
+ */
+int mbedtls_mng_otpWordRead(uint32_t otpAddress,            /*!< [in]       OTP Address: An Offset in Words in the OTP address space. */
+                uint32_t *pOtpWord);            /*!< [in/out]   OTP Word pointer: An address to store the read Word. */
+
+/*!
+@brief This function returns the LCS value'.
+
+@return CC_OK on success.
+@return A non-zero value from cc_manage.h on failure.
+ */
+int mbedtls_mng_lcsGet(uint32_t *pLcs);                 /*!< [in/out]   LCS Value: An address to store the LCS Value. */
+
+/*!
+@brief This function reads software revocation counter from OTP memory, according to the provided key index.
+
+@return CC_OK on success.
+@return A non-zero value from cc_manage.h on failure.
+*/
+int mbedtls_mng_swVersionGet(
+                mbedtls_mng_pubKeyType_t keyIndex,      /*!< [in] Enumeration defining the key hash to retrieve: 128-bit HBK0, 128-bit HBK1, or 256-bit HBK. */
+    uint32_t *swVersion                                 /*!< [out] The value of the requested counter as read from OTP memory. */
+    );
+
+/*!
+@brief This function retrieves the public key hash from OTP memory, according to the provided index.
+
+@return CC_OK on success.
+@return A non-zero value from cc_manage.h on failure.
+*/
+int mbedtls_mng_pubKeyHashGet(
+                mbedtls_mng_pubKeyType_t keyIndex,      /*!< [in] Enumeration defining the key hash to retrieve: 128-bit HBK0, 128-bit HBK1, or 256-bit HBK. */
+                uint32_t *hashedPubKey,                 /*!< [out] A buffer to contain the public key HASH. */
+                uint32_t hashResultSizeWords            /*!< [in] The size of the hash in 32-bit words:
+                                                        - Must be 4 for 128-bit hash.
+                                                        - Must be 8 for 256bit hash. */
+    );
+
+#endif // _MBEDTLS_CC_MNG_COMMON_H

--- a/host/src/cc_mng/mbedtls_cc_mng_int.h
+++ b/host/src/cc_mng/mbedtls_cc_mng_int.h
@@ -12,17 +12,9 @@
 #include "cc_regs.h"
 #include "dx_nvm.h"
 #include "cc_pal_types_plat.h"
+#include "mbedtls_cc_mng_common.h"
 
 /************************ Enums ******************************/
-/*! HASH boot key definition. */
-typedef enum {
-    CC_MNG_HASH_BOOT_KEY_0_128B         = 0,        /*!< 128-bit truncated SHA256 digest of public key 0. */
-    CC_MNG_HASH_BOOT_KEY_1_128B     = 1,        /*!< 128-bit truncated SHA256 digest of public key 1. */
-    CC_MNG_HASH_BOOT_KEY_256B       = 2,        /*!< 256-bit SHA256 digest of public key. */
-    CC_MNG_HASH_BOOT_NOT_USED       = 0xF,
-    CC_MNG_HASH_MAX_NUM                 = 0x7FFFFFFF,   /*!\internal use external 128-bit truncated SHA256 digest */
-}mbedtls_mng_pubKeyType_t;
-
 /************************ Defines ******************************/
 #define CC_MNG_INVALID_REG_VAL          0xFFFFFFFF
 
@@ -130,50 +122,6 @@ typedef enum {
         val = ((((val + (val >> 4)) & 0xF0F0F0F) * 0x1010101) >> 24);   \
         regZero += (32 - val);                      \
     }while(0)
-
-
-/************************ API's ******************************/
-/*!
-@brief This function reads an OTP word from from 'otpAddress' to 'pOtpWord'.
-
-@return CC_OK on success.
-@return A non-zero value from cc_manage.h on failure.
- */
-int mbedtls_mng_otpWordRead(uint32_t otpAddress,            /*!< [in]       OTP Address: An Offset in Words in the OTP address space. */
-                uint32_t *pOtpWord);            /*!< [in/out]   OTP Word pointer: An address to store the read Word. */
-
-/*!
-@brief This function returns the LCS value'.
-
-@return CC_OK on success.
-@return A non-zero value from cc_manage.h on failure.
- */
-int mbedtls_mng_lcsGet(uint32_t *pLcs);                 /*!< [in/out]   LCS Value: An address to store the LCS Value. */
-
-/*!
-@brief This function reads software revocation counter from OTP memory, according to the provided key index.
-
-@return CC_OK on success.
-@return A non-zero value from cc_manage.h on failure.
-*/
-int mbedtls_mng_swVersionGet(
-                mbedtls_mng_pubKeyType_t keyIndex,      /*!< [in] Enumeration defining the key hash to retrieve: 128-bit HBK0, 128-bit HBK1, or 256-bit HBK. */
-    uint32_t *swVersion                                 /*!< [out] The value of the requested counter as read from OTP memory. */
-    );
-
-/*!
-@brief This function retrieves the public key hash from OTP memory, according to the provided index.
-
-@return CC_OK on success.
-@return A non-zero value from cc_manage.h on failure.
-*/
-int mbedtls_mng_pubKeyHashGet(
-                mbedtls_mng_pubKeyType_t keyIndex,      /*!< [in] Enumeration defining the key hash to retrieve: 128-bit HBK0, 128-bit HBK1, or 256-bit HBK. */
-                uint32_t *hashedPubKey,                 /*!< [out] A buffer to contain the public key HASH. */
-                uint32_t hashResultSizeWords            /*!< [in] The size of the hash in 32-bit words:
-                                                        - Must be 4 for 128-bit hash.
-                                                        - Must be 8 for 256bit hash. */
-    );
 
 #endif // _MBEDTLS_CC_MNG_INT_H
 

--- a/shared/include/cc_mng/mbedtls_cc_mng.h
+++ b/shared/include/cc_mng/mbedtls_cc_mng.h
@@ -34,16 +34,6 @@ extern "C"
 
 
 /* *********************** Defines ***************************** */
-/* LCS. */
-/*! Chip manufacturer (CM LCS). */
-#define CC_MNG_LCS_CM       0x0
-/*! Device manufacturer (DM LCS). */
-#define CC_MNG_LCS_DM       0x1
-/*! Security enabled (Secure LCS). */
-#define CC_MNG_LCS_SEC_ENABLED  0x5
-/*! RMA (RMA LCS). */
-#define CC_MNG_LCS_RMA      0x7
-
 /* *********************** Macros ***************************** */
 
 


### PR DESCRIPTION
Add cut-down header to allow LCS functionality to be accessed more easily.